### PR TITLE
JSON receipts

### DIFF
--- a/lib/oja/receipt.rb
+++ b/lib/oja/receipt.rb
@@ -2,7 +2,7 @@ require 'base64'
 
 module Oja
   class Receipt
-    attr_accessor :filename, :password
+    attr_accessor :filename, :password, :format
     attr_writer :data
 
     def initialize(attributes)
@@ -32,9 +32,18 @@ module Oja
     end
 
     def attributes
-      attributes = { 'receipt-data' => receipt_data }
+      if json?
+        attributes = JSON.parse(data)
+      else
+        attributes = { 'receipt-data' => receipt_data }
+      end
+
       attributes['password'] = password if password
       attributes
+    end
+
+    def json?
+      format == :json
     end
 
     def to_json

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -9,7 +9,7 @@ describe Oja::CLI do
 
   it "verifies a receipt from disk" do
     Oja::Mock.responses << [200, { status: Oja::Response.status_code(:active), receipt: { 'product_id' => 'day' }}]
-    cli = Oja::CLI.new([receipt_filename('receipt')])
+    cli = Oja::CLI.new([receipt_filename('receipt.txt')])
     output = capture_stdout do
       cli.run
     end.to_s
@@ -18,13 +18,13 @@ describe Oja::CLI do
   end
 
   it "allows you to pass a password" do
-    cli = Oja::CLI.new([receipt_filename('receipt'), '--password', 'secret'])
+    cli = Oja::CLI.new([receipt_filename('receipt.txt'), '--password', 'secret'])
     cli.password.should == 'secret'
   end
 
   it "shows a message when the receipt is invalid" do
     Oja::Mock.responses << [200, { status: Oja::Response.status_code(:inactive) }]
-    output = oja(receipt_filename('receipt'))
+    output = oja(receipt_filename('receipt.txt'))
     output.should.include 'Receipt is invalid (Inactive)'
   end
 

--- a/spec/oja_spec.rb
+++ b/spec/oja_spec.rb
@@ -3,38 +3,38 @@ require 'oja/mock'
 
 describe Oja do
   it "verifies receipt data" do
-    response = Oja.verify(receipt_data('receipt'))
+    response = Oja.verify(receipt_data('receipt.txt'))
     # The default for the mock response is success
     response.should.be.active
   end
 
   it "verifies receipt data with a password" do
-    response = Oja.verify(receipt_data('receipt'), 'secret')
+    response = Oja.verify(receipt_data('receipt.txt'), 'secret')
     # The default for the mock response is success
     response.should.be.active
   end
 
   it "verifies receipt data passed in an option hash" do
-    response = Oja.verify(:data => receipt_data('receipt'))
+    response = Oja.verify(:data => receipt_data('receipt.txt'))
     # The default for the mock response is success
     response.should.be.active
   end
 
   it "verifies an active receipt from disk" do
-    response = Oja.verify_filename(receipt_filename('receipt'))
+    response = Oja.verify_filename(receipt_filename('receipt.txt'))
     # The default for the mock response is success
     response.should.be.active
   end
 
   it "verifies an inactive receipt from disk" do
     Oja::Mock.responses << [200, { status: Oja::Response.status_code(:inactive) }]
-    response = Oja.verify_filename(receipt_filename('receipt'))
+    response = Oja.verify_filename(receipt_filename('receipt.txt'))
     response.should.be.inactive
   end
 
   it "does not return a response when the HTTP request fails" do
     Oja::Mock.responses << [500, {}]
-    response = Oja.verify_filename(receipt_filename('receipt'))
+    response = Oja.verify_filename(receipt_filename('receipt.txt'))
     response.should == nil
   end
 end

--- a/spec/preamble.rb
+++ b/spec/preamble.rb
@@ -38,7 +38,7 @@ class Peck::Context
   end
 
   def receipt_filename(name)
-    filename = File.expand_path("../fixtures/receipts/#{name}.txt", __FILE__)
+    filename = File.expand_path("../fixtures/receipts/#{name}", __FILE__)
     if File.exist?(filename)
       filename
     else

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -2,28 +2,28 @@ require File.expand_path('../preamble', __FILE__)
 
 describe Oja::Receipt do
   it "loads a receipt from disk" do
-    receipt = Oja::Receipt.new(:filename => receipt_filename('receipt'))
-    receipt.data.should == receipt_data('receipt')
+    receipt = Oja::Receipt.new(:filename => receipt_filename('receipt.txt'))
+    receipt.data.should == receipt_data('receipt.txt')
   end
 
   it "accepts data for a receipt" do
-    receipt = Oja::Receipt.new(:data => receipt_data('receipt'))
-    receipt.data.should == receipt_data('receipt')
+    receipt = Oja::Receipt.new(:data => receipt_data('receipt.txt'))
+    receipt.data.should == receipt_data('receipt.txt')
   end
 
   it "includes the Base64 encoded receipt data in its attributes" do
-    data = receipt_data('receipt')
+    data = receipt_data('receipt.txt')
     receipt = Oja::Receipt.new(:data => data)
     receipt.attributes['receipt-data'].should == Base64.encode64(data)
   end
 
   it "includes the password in its attributes when it's configured" do
-    receipt = Oja::Receipt.new(:data => receipt_data('receipt'), :password => 'secret')
+    receipt = Oja::Receipt.new(:data => receipt_data('receipt.txt'), :password => 'secret')
     receipt.attributes['password'].should == 'secret'
   end
 
   it "includes the password in its JSON when it's configured" do
-    receipt = Oja::Receipt.new(:data => receipt_data('receipt'), :password => 'secret')
+    receipt = Oja::Receipt.new(:data => receipt_data('receipt.txt'), :password => 'secret')
     JSON.parse(receipt.to_json)['password'].should == 'secret'
   end
 end

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -26,4 +26,9 @@ describe Oja::Receipt do
     receipt = Oja::Receipt.new(:data => receipt_data('receipt.txt'), :password => 'secret')
     JSON.parse(receipt.to_json)['password'].should == 'secret'
   end
+
+  it "accepts JSON data as the receipt" do
+    receipt = Oja::Receipt.new(:data => receipt_data('receipt.json'), format: :json)
+    receipt.data.should == receipt_data('receipt.json')
+  end
 end


### PR DESCRIPTION
Since iOS 7.0, Apple expects you encode the receipt and build the JSON file in the app. Because we still need to support older versions, there's a `format` accessor now that makes `Oja::Receipt#attributes` use `data` without going through the encoding step.
